### PR TITLE
Use StateT monad throughout

### DIFF
--- a/lambdaboy.cabal
+++ b/lambdaboy.cabal
@@ -47,7 +47,7 @@ library
       AllowAmbiguousTypes
       FlexibleInstances
   build-depends:
-      base >=4.7 && <5
+      base >= 4.7 && <5
     , array
     , mtl
   default-language: Haskell2010
@@ -91,8 +91,9 @@ test-suite lambdaboy-test
       FlexibleInstances
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      base >= 4.7 && <5
     , array
+    , mtl
     , HUnit
     , lambdaboy
   default-language: Haskell2010

--- a/src/Gameboy.hs
+++ b/src/Gameboy.hs
@@ -3,6 +3,7 @@ module Gameboy
     )
 where
 
+import Control.Monad.State.Lazy
 import Data.Array.MArray
 import Data.Word
 
@@ -12,22 +13,24 @@ import qualified CPU (step)
 data Gameboy a m where
   Gameboy :: MArray a Word8 m => { cpu :: CPU a m } -> Gameboy a m
 
+-- TODO: actually load a cart
 loadCart :: MArray a Word8 m => m (Gameboy a m)
 loadCart = Gameboy <$> initCPU
 
-step :: MArray a Word8 m => Gameboy a m -> m (Gameboy a m)
-step gameboy = do
-  cpu' <- CPU.step (cpu gameboy)
-  return $ gameboy { cpu = cpu' }
+step :: MArray a Word8 m => StateT (Gameboy a m) m ()
+step = do
+  gb <- get
+  cpu' <- lift $ execStateT CPU.step (cpu gb)
+  put $ gb { cpu = cpu' }
 
-_run :: MArray a Word8 m => Gameboy a m -> m (Gameboy a m)
-_run gameboy = do
-  gameboy' <- step gameboy
-  if (running . cpu) gameboy' then _run gameboy' else return gameboy'
+_run :: MArray a Word8 m => StateT (Gameboy a m) m ()
+_run = do
+  step
+  gb <- get
+  when ((running . cpu) gb) _run
 
--- TODO: actually load a cart
 run :: forall a m. MArray a Word8 m => m ()
 run = do
   gameboy <- loadCart @a
-  _ <- _run gameboy -- TODO: check final state
+  _ <- execStateT _run gameboy
   return ()

--- a/test/CPUTests.hs
+++ b/test/CPUTests.hs
@@ -5,6 +5,7 @@ where
 
 import Prelude hiding (and)
 
+import Control.Monad.State.Lazy
 import Control.Monad.ST
 import Data.Array
 import Data.Array.ST
@@ -33,21 +34,21 @@ loadR8R8 :: Test
 loadR8R8 = "LD r8, r8" ~: reg8 RegB (resultRegisters resultCPU) ~?= 0xF where
   resultCPU = runST $ do
     cpu <- withRegisters (setReg8 RegA 0xF emptyRegisters) emptyCPU
-    cpu' <- load (Reg8 RegB) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Reg8 RegB) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadR8N8 :: Test
 loadR8N8 = "LD r8, n8" ~: reg8 RegB (resultRegisters resultCPU) ~?= 0xF where
   resultCPU = runST $ do
     cpu <- emptyCPU
-    cpu' <- load (Reg8 RegB) (Uimm8 0xF) cpu
+    cpu' <- execStateT (load (Reg8 RegB) (Uimm8 0xF)) cpu
     toResultCPU cpu'
 
 loadR16N16 :: Test
 loadR16N16 = "LD r16, n16" ~: reg16 RegB RegC (resultRegisters resultCPU) ~?= 0x1111 where
   resultCPU = runST $ do
     cpu <- emptyCPU
-    cpu' <- load (Reg16 RegB RegC) (Uimm16 0x1111) cpu
+    cpu' <- execStateT (load (Reg16 RegB RegC) (Uimm16 0x1111)) cpu
     toResultCPU cpu'
 
 loadIndirectHLR8 :: Test
@@ -55,7 +56,7 @@ loadIndirectHLR8 = "LD (HL), r8" ~: resultRAM resultCPU ! 0x1111 ~?= 0xF where
   resultCPU = runST $ do
     let regs = setReg16 RegH RegL 0x1111 (setReg8 RegC 0xF emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- load (Indirect (Reg16 RegH RegL)) (Reg8 RegC) cpu
+    cpu' <- execStateT (load (Indirect (Reg16 RegH RegL)) (Reg8 RegC)) cpu
     toResultCPU cpu'
 
 loadR8IndirectHL :: Test
@@ -63,7 +64,7 @@ loadR8IndirectHL = "LD r8, (HL)" ~: reg8 RegC (resultRegisters resultCPU) ~?= 0x
   resultCPU = runST $ do
     cpu <- withRegisters (setReg16 RegH RegL 0x1111 emptyRegisters) emptyCPU
     writeArray (ram cpu) 0x1111 0xF
-    cpu' <- load (Reg8 RegC) (Indirect (Reg16 RegH RegL)) cpu
+    cpu' <- execStateT (load (Reg8 RegC) (Indirect (Reg16 RegH RegL))) cpu
     toResultCPU cpu'
 
 loadIndirectR16RA :: Test
@@ -71,21 +72,21 @@ loadIndirectR16RA = "LD (r16), A" ~: resultRAM resultCPU ! 0x1111 ~?= 0xF where
   resultCPU = runST $ do
     let regs = setReg8 RegA 0xF (setReg16 RegB RegC 0x1111 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- load (Indirect (Reg16 RegB RegC)) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (Reg16 RegB RegC)) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadIndirectN16RA :: Test
 loadIndirectN16RA = "LD (n16), A" ~: resultRAM resultCPU ! 0x1111 ~?= 0xF where
   resultCPU = runST $ do
     cpu <- withRegisters (setReg8 RegA 0xF emptyRegisters) emptyCPU
-    cpu' <- load (Indirect (Uimm16 0x1111)) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (Uimm16 0x1111)) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadFF00N8RA :: Test
 loadFF00N8RA = "LD ($FF00 + n8), A" ~: resultRAM resultCPU ! 0xFF01 ~?= 0xF where
   resultCPU = runST $ do
     cpu <- withRegisters (setReg8 RegA 0xF emptyRegisters) emptyCPU
-    cpu' <- load (Indirect (FF00Offset (Uimm8 0x1))) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (FF00Offset (Uimm8 0x1))) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadFF00RCRA :: Test
@@ -93,7 +94,7 @@ loadFF00RCRA = "LD ($FF00 + C), A" ~: resultRAM resultCPU ! 0xFF01 ~?= 0xF where
   resultCPU = runST $ do
     let regs = setReg8 RegC 0x1 $ setReg8 RegA 0xF emptyRegisters
     cpu <- withRegisters regs emptyCPU
-    cpu' <- load (Indirect (FF00Offset (Uimm8 0x1))) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (FF00Offset (Uimm8 0x1))) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadRAIndirectR16 :: Test
@@ -101,7 +102,7 @@ loadRAIndirectR16 = "LD A, (r16)" ~: reg8 RegA (resultRegisters resultCPU) ~?= 0
   resultCPU = runST $ do
     cpu <- withRegisters (setReg16 RegB RegC 0x1111 emptyRegisters) emptyCPU
     writeArray (ram cpu) 0x1111 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (Reg16 RegB RegC)) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (Reg16 RegB RegC))) cpu
     toResultCPU cpu'
 
 loadRAIndirectN16 :: Test
@@ -109,7 +110,7 @@ loadRAIndirectN16 = "LD A, (n16)" ~: reg8 RegA (resultRegisters resultCPU) ~?= 0
   resultCPU = runST $ do
     cpu <- emptyCPU
     writeArray (ram cpu) 0x1111 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (Uimm16 0x1111)) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (Uimm16 0x1111))) cpu
     toResultCPU cpu'
 
 loadRAFF00N8 :: Test
@@ -117,7 +118,7 @@ loadRAFF00N8 = "LD A, ($FF00 + n8)" ~: reg8 RegA (resultRegisters resultCPU) ~?=
   resultCPU = runST $ do
     cpu <- emptyCPU
     writeArray (ram cpu) 0xFF01 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (FF00Offset (Uimm8 0x1))) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (FF00Offset (Uimm8 0x1)))) cpu
     toResultCPU cpu'
 
 
@@ -126,7 +127,7 @@ loadRAFF00RC = "LD A, ($FF00 + C)" ~: reg8 RegA (resultRegisters resultCPU) ~?= 
   resultCPU = runST $ do
     cpu <- withRegisters (setReg8 RegC 0x1 emptyRegisters) emptyCPU
     writeArray (ram cpu) 0xFF01 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (FF00Offset (Reg8 RegC))) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (FF00Offset (Reg8 RegC)))) cpu
     toResultCPU cpu'
 
 loadIndirectHLIRA :: Test
@@ -137,7 +138,7 @@ loadIndirectHLIRA =
   resultCPU = runST $ do
     let regs = setReg16 RegH RegL 0x1111 (setReg8 RegA 0xF emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- load (Indirect (PostInstruction (Reg16 RegH RegL) IncrementAfter)) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (PostInstruction (Reg16 RegH RegL) IncrementAfter)) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadIndirectHLDRA :: Test
@@ -148,7 +149,7 @@ loadIndirectHLDRA =
   resultCPU = runST $ do
     let regs = setReg16 RegH RegL 0x1111 (setReg8 RegA 0xF emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- load (Indirect (PostInstruction (Reg16 RegH RegL) DecrementAfter)) (Reg8 RegA) cpu
+    cpu' <- execStateT (load (Indirect (PostInstruction (Reg16 RegH RegL) DecrementAfter)) (Reg8 RegA)) cpu
     toResultCPU cpu'
 
 loadRAIndirectHLI :: Test
@@ -159,7 +160,7 @@ loadRAIndirectHLI =
   resultCPU = runST $ do
     cpu <- withRegisters (setReg16 RegH RegL 0x1111 emptyRegisters) emptyCPU
     writeArray (ram cpu) 0x1111 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (PostInstruction (Reg16 RegH RegL) IncrementAfter)) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (PostInstruction (Reg16 RegH RegL) IncrementAfter))) cpu
     toResultCPU cpu'
 
 
@@ -171,14 +172,14 @@ loadRAIndirectHLD =
   resultCPU = runST $ do
     cpu <- withRegisters (setReg16 RegH RegL 0x1111 emptyRegisters) emptyCPU
     writeArray (ram cpu) 0x1111 0xF
-    cpu' <- load (Reg8 RegA) (Indirect (PostInstruction (Reg16 RegH RegL) DecrementAfter)) cpu
+    cpu' <- execStateT (load (Reg8 RegA) (Indirect (PostInstruction (Reg16 RegH RegL) DecrementAfter))) cpu
     toResultCPU cpu'
 
 loadSPN16 :: Test
 loadSPN16 = "LD SP, n16" ~: resultSP resultCPU ~?= 0xFFFF where
   resultCPU = runST $ do
     cpu <- emptyCPU
-    cpu' <- load (StackPointer Unchanged) (Uimm16 0xFFFF) cpu
+    cpu' <- execStateT (load (StackPointer Unchanged) (Uimm16 0xFFFF)) cpu
     toResultCPU cpu'
 
 loadIndirectN16SP :: Test
@@ -188,7 +189,7 @@ loadIndirectN16SP =
                              ] where
   resultCPU = runST $ do
     cpu <- withSP 0xFFFF emptyCPU
-    cpu' <- load (Indirect (Uimm16 0x1111)) (StackPointer Unchanged) cpu
+    cpu' <- execStateT (load (Indirect (Uimm16 0x1111)) (StackPointer Unchanged)) cpu
     toResultCPU cpu'
 
 loadHLSPE8 :: Test
@@ -199,14 +200,14 @@ loadHLSPE8 =
                                ] where
   resultCPU = runST $ do
     cpu <- withSP 0xFFFF emptyCPU
-    cpu' <- load (Reg16 RegH RegL) (StackPointer (AddInt8 1)) cpu
+    cpu' <- execStateT (load (Reg16 RegH RegL) (StackPointer (AddInt8 1))) cpu
     toResultCPU cpu'
 
 loadSPHL :: Test
 loadSPHL = "LD SP, HL" ~: resultSP resultCPU ~?= 0xFFFF where
   resultCPU = runST $ do
     cpu <- withRegisters (setReg16 RegH RegL 0xFFFF emptyRegisters) emptyCPU
-    cpu' <- load (StackPointer Unchanged) (Reg16 RegH RegL) cpu
+    cpu' <- execStateT (load (StackPointer Unchanged) (Reg16 RegH RegL)) cpu
     toResultCPU cpu'
 
 loadTests :: Test
@@ -250,7 +251,7 @@ addRAR8 = TestList [ "ADD A, r8" ~: add8Expected WithoutCarryIncluded (resultCPU
   resultCPU at = runST $ do
     let regs = setReg8 RegA 0xFF (setReg8 RegB 0x01 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- add at (Reg8 RegA) (Reg8 RegB) cpu
+    cpu' <- execStateT (add at (Reg8 RegA) (Reg8 RegB)) cpu
     toResultCPU cpu'
 
 addRAIndirectHL :: Test
@@ -261,7 +262,7 @@ addRAIndirectHL = TestList [ "ADD A, (HL)" ~: add8Expected WithoutCarryIncluded 
     let regs = setReg8 RegA 0xFF (setReg16 RegH RegL 0x1111 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
     writeArray (ram cpu) 0x1111 0x1
-    cpu' <- add at (Reg8 RegA) (Indirect (Reg16 RegH RegL)) cpu
+    cpu' <- execStateT (add at (Reg8 RegA) (Indirect (Reg16 RegH RegL))) cpu
     toResultCPU cpu'
 
 addRAN8 :: Test
@@ -270,7 +271,7 @@ addRAN8 = TestList [ "ADD A, n8" ~: add8Expected WithoutCarryIncluded (resultCPU
                    ] where
   resultCPU at = runST $ do
     cpu <- withRegisters (setReg8 RegA 0xFF emptyRegisters) emptyCPU
-    cpu' <- add at (Reg8 RegA) (Uimm8 0x1) cpu
+    cpu' <- execStateT (add at (Reg8 RegA) (Uimm8 0x1)) cpu
     toResultCPU cpu'
 
 addHLR16 :: Test
@@ -283,7 +284,7 @@ addHLR16 = "ADD HL, r16" ~: TestList [ "registers updated" ~: reg16 RegH RegL (r
   resultCPU = runST $ do
     let regs = setReg16 RegH RegL 0xFFFF (setReg16 RegB RegC 0x0001 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- add WithoutCarryIncluded (Reg16 RegH RegL) (Reg16 RegB RegC) cpu
+    cpu' <- execStateT (add WithoutCarryIncluded (Reg16 RegH RegL) (Reg16 RegB RegC)) cpu
     toResultCPU cpu'
 
 addHLSP :: Test
@@ -296,7 +297,7 @@ addHLSP = "ADD HL, r16" ~: TestList [ "registers updated" ~: reg16 RegH RegL (re
   resultCPU = runST $ do
     let regs = setReg16 RegH RegL 0xFFFF emptyRegisters
     cpu <- withSP 0x0001 $ withRegisters regs emptyCPU
-    cpu' <- add WithoutCarryIncluded (Reg16 RegH RegL) (StackPointer Unchanged) cpu
+    cpu' <- execStateT (add WithoutCarryIncluded (Reg16 RegH RegL) (StackPointer Unchanged)) cpu
     toResultCPU cpu'
 
 addSPE8 :: Test
@@ -307,7 +308,7 @@ addSPE8 =
                            ] where
   resultCPU = runST $ do
     cpu <- withSP 0xFFFF emptyCPU
-    cpu' <- add WithoutCarryIncluded (StackPointer Unchanged) (Imm8 1) cpu
+    cpu' <- execStateT (add WithoutCarryIncluded (StackPointer Unchanged) (Imm8 1)) cpu
     toResultCPU cpu'
 
 addTests :: Test
@@ -327,7 +328,7 @@ andRAR8 = "AND A, R8" ~: TestList [ "register updated" ~: reg8 RegA (resultRegis
   resultCPU = runST $ do
     let regs = setReg8 RegA 0x1 (setReg8 RegB 0x10 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
-    cpu' <- and (Reg8 RegA) (Reg8 RegB) cpu
+    cpu' <- execStateT (and (Reg8 RegA) (Reg8 RegB)) cpu
     toResultCPU cpu'
 
 andRAHL :: Test
@@ -339,7 +340,7 @@ andRAHL = "AND A, [HL]" ~: TestList [ "register updated" ~: reg8 RegA (resultReg
     let regs = setReg8 RegA 0x1 (setReg16 RegH RegL 0x1111 emptyRegisters)
     cpu <- withRegisters regs emptyCPU
     writeArray (ram cpu) 0x1111 0x10
-    cpu' <- and (Reg8 RegA) (Indirect (Reg16 RegH RegL)) cpu
+    cpu' <- execStateT (and (Reg8 RegA) (Indirect (Reg16 RegH RegL))) cpu
     toResultCPU cpu'
 
 andRAN8 :: Test
@@ -350,7 +351,7 @@ andRAN8 = "AND A, n8" ~: TestList [ "register updated" ~: reg8 RegA (resultRegis
   resultCPU = runST $ do
     let regs = setReg8 RegA 0x1 emptyRegisters
     cpu <- withRegisters regs emptyCPU
-    cpu' <- and (Reg8 RegA) (Uimm8 0x10) cpu
+    cpu' <- execStateT (and (Reg8 RegA) (Uimm8 0x10)) cpu
     toResultCPU cpu'
 
 andTests :: Test


### PR DESCRIPTION
I removed the state monad transformer in `Gameboy` because I wasn't really using it. It is still not incredibly useful there (as `Gameboy` is mostly empty at the moment), but `CPU` had a _lot_ of code that would have benefited from the State monad since a lot of CPU state was being passed around.

With this motivation, I added back use of the StateT monad throughout, both in `CPU` and in `Gameboy`. Two "separate" states are being threaded, at each gameboy step `execStateT` is called with the current CPU state on `CPU.step` (to not pass the entire Gameboy state to the CPU). This is not as clean as I'd like it to be, but I couldn't find a great solution for this after some quick searching.

---
A `TODO` was also swallowed up in this PR, `evalOp` is now `evalOpWord8`. Some of the function's type safety is lost and it now has unreachable code, which is also not great. I couldn't get type families to work in my favor here to convert the evidence that an `ADD` operand must be a `Word8` operand (and use the same trick for `AND` and eventually other arithmetic/logic instructions), so I went with this for now as at least the code does feel _pretty_ unreachable thanks to using type families to constrict operands. I have a fear that using type families like I am may make writing reusable code a little tricky, so I will try to focus on `loadInstruction` before going further with more instruction's execution implementation and see how much of a pain it is to create an instruction using some shared code.