### PR TITLE
Code that cannot compile

### DIFF
--- a/src/CPU.hs
+++ b/src/CPU.hs
@@ -212,7 +212,13 @@ and (Reg8 RegA) op = do
 
 -- TODO: implement
 fetchInstruction :: Monad m => StateT (CPU a m) m Ins
-fetchInstruction = undefined
+fetchInstruction = do
+  cpu <- get
+  case pc cpu of
+    0 ->
+      let r = if True then RegB else RegC in
+      return $ Ins (Add WithCarryIncluded (Reg8 RegA) (Reg8 r))
+    _ -> return $ Ins (Add WithCarryIncluded (Reg8 RegA) (Uimm8 10))
 
 executeInstruction :: MArray a Word8 m => Instruction k -> StateT (CPU a m) m ()
 executeInstruction (Load o1 o2) = load o1 o2


### PR DESCRIPTION
As mentioned in the latter half of https://github.com/emmanueljs1/lambdaboy/pull/1, there is an issue with how constraining the current architecture of type families is towards code reusability.

The following code is a simplified example of a desired use case: loading _any_ register as the second operand to an `ADD` instruction that has the `A` register as its first operand (this will also be needed for other arithmetic/logic instructions). Currently, this doesn't compile. A decent compromise here is to make `Reg8` 's kind not have the specific register, and add special operands for those that are commonly restricted (as is done for `RegAF` currently). This more accurately reflects the flow of decoding and executing an instruction as well.

This does not fully alleviate the issue of `evalOpWord8`'s unreachable code, but it is a start (for this use case, a `Word8Operand` type class with an `eval` method may be the solution)