### PR TITLE
Add QuickCheck property for load instruction

### DIFF
--- a/src/Registers.hs
+++ b/src/Registers.hs
@@ -4,7 +4,7 @@ module Registers
   , CombinedRegs
   , Reg (..)
   , Registers
-  , emptyRegisters
+  , initRegisters
   , setReg8
   , reg8
   , setReg16
@@ -12,10 +12,11 @@ module Registers
   )
 where
 
+import Control.Monad (join)
 import Data.Bits
-import Data.Kind
+import Data.List (intersperse)
 import Data.Word
-import Type.Reflection (typeRep, Typeable)
+import Test.QuickCheck (Arbitrary, arbitrary)
 
 data RegType
   = A
@@ -25,7 +26,7 @@ data RegType
   | E
   | H
   | L
-  deriving (Show, Typeable)
+  deriving Show
 
 data RegsCompatible = RegsCompatible
 
@@ -62,8 +63,16 @@ data Registers = Registers {
   regL :: Word8
 }
 
-emptyRegisters :: Registers
-emptyRegisters = Registers 0 0 0 0 0 0 0
+instance Show Registers where
+  show (Registers a b c d e h l) = "{" ++ join listed ++ "}"  where
+    listed = intersperse ", " $ map (\(x,y) -> x ++ "=" ++ show y) lst
+    lst = zip ["A","B","C","D","E","H","L"] [a, b, c, d, e, h, l]
+
+instance Arbitrary Registers where
+  arbitrary = Registers <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+initRegisters :: Registers
+initRegisters = Registers 0 0 0 0 0 0 0
 
 setReg8 :: Reg r -> Word8 -> Registers -> Registers
 setReg8 RegA n8 rs = rs { regA = n8 }


### PR DESCRIPTION
To add a property for the load instruction, it made the most sense to add an arbitrary instance for `Instruction 'KLoad`**. For this to be possible, arbitrary instances for operands had to be added as well. This was a little tricky given that any operand data constructor's type was tagged with an informative kind (as first seen [here](https://github.com/emmanueljs1/lambdaboy/issues/3)). To remediate this, typing was relaxed for many operand data constructors somewhat, in the same way that was done for the `Reg8` data constructor in the PR linked in the mentioned issue. That said, to maintain the desired functionality of it being impossible to create a malformed CPU instruction, special data constructors were added (as has already been done with `RegisterA` and `RegisterC`).

To fully take advantage of quickcheck, `ResultCPU` has been upgraded to `FrozenCPU`, with its own arbitrary instance and some convenience methods. The initial load instruction property takes an arbitrary CPU state and confirms that the second operand's value is loaded onto the first operand.

For similar convenience, custom `Show` instances have been implemented for all operands and for the load instruction.

**BUG FIX**: Additionally, while testing I found that `ram` was not addressable up until `0xFFFF` but rather of _size_ `0xFFFF`. This was annoying to get to work with the invariant that addresses of `ram` are `Word16`, as it is impossible to express the actual size of `ram` (`0x10000`) as a `Word16`. To keep the invariant that the addresses of `ram` are `Word16`, there is now a single element array to represent element `0xFFFF` of RAM. This had the nice side effect that `ram` is now abstracted as its own type (though ideally this change would take place _and_ there wouldn't be a need to have such a tacky fix).

---

** Note: it is very likely that `Instruction` will have kind `*` later on and not be parametrized by the kind of its data constructor's instruction, so there will only be one arbitrary instance for `Instruction`